### PR TITLE
#106 - fazer rota de update de equipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   [#84](https://github.com/KozielGPC/championship-platform/issues/84) - Resolvida validação do formulário de campeonato no frontend
 
 ### Added
+-   [#106](https://github.com/KozielGPC/championship-platform/issues/106) - Adicionado rota de update para Teams e validações extras na criação de Teams
 -   [#79](https://github.com/KozielGPC/championship-platform/issues/79) - Adicionado validação nos nomes de times e campeonatos
 -   [#39](https://github.com/KozielGPC/championship-platform/issues/39) - Adicionado frontend da Home Screen
 -   [#74](https://github.com/KozielGPC/championship-platform/issues/74) - Adicionado arquivos de configuração para deploy no fly.io

--- a/backend/api/routers/teams_routes.py
+++ b/backend/api/routers/teams_routes.py
@@ -79,8 +79,6 @@ async def update(id: int, update_request: TeamUpdateRequest, token: Annotated[st
             raise HTTPException(status_code=400, detail="Team with this name already exists")
 
     if update_request.password:
-        if update_request.password == "":
-            raise HTTPException(status_code=400, detail="Password can not be empty")
         update_request.password = get_password_hash(update_request.password)
 
     update_data = update_request.dict(exclude_unset=True)

--- a/backend/api/routers/teams_routes.py
+++ b/backend/api/routers/teams_routes.py
@@ -1,6 +1,7 @@
 from api.database.config import Session, engine
-from api.schemas.teams import Response, TeamInput, TeamSchema
+from api.schemas.teams import Response, TeamInput, TeamSchema, TeamUpdateRequest
 from api.models.teams import Team
+from api.models.games import Game
 from api.utils.auth_services import get_password_hash, oauth2_scheme, get_current_user
 from fastapi import APIRouter, HTTPException, Depends
 from typing import Annotated
@@ -45,24 +46,51 @@ async def getById(id: int):
     response_description="Sucesso de resposta da aplicação.",
 )
 async def create(data: TeamInput, token: Annotated[str, Depends(oauth2_scheme)]):
-    # Falta fazer as validações para criar o time (acho q nao falta mais)
     team = session.query(Team).filter(Team.name == data.name).first()
     if team != None:
         raise HTTPException(status_code=400, detail="Team with this name already exists")
+
+    game = session.query(Game).filter(Game.id == data.game_id).first()
+    if game == None:
+        raise HTTPException(status_code=404, detail="Game not Found")
+
     hashed_password = get_password_hash(data.password)
     user = await get_current_user(token)
     team_input = Team(name=data.name, password=hashed_password, owner_id=user.id, game_id=data.game_id)
     session.add(team_input)
     session.commit()
     session.refresh(team_input)
-    response = {
-        "id": team_input.id,
-        "name": team_input.name,
-        "password": team_input.password,
-        "owner_id": team_input.owner_id,
-        "game_id": team_input.game_id
-    }
-    return response
+    return team_input
+
+
+@router.put(
+    "/update/{id}", status_code=200, response_model=TeamSchema, response_description="Sucesso de resposta da aplicação."
+)
+async def update(id: int, update_request: TeamUpdateRequest, token: Annotated[str, Depends(oauth2_scheme)]):
+    user = await get_current_user(token)
+    team = session.query(Team).filter(Team.id == id, user.id == Team.owner_id).first()
+
+    if team == None:
+        raise HTTPException(status_code=404, detail="Team not found or You aren't the owner of the team")
+
+    if update_request.name:
+        team_exists = session.query(Team).filter(Team.name == update_request.name, Team.id != id).first()
+        if team_exists != None:
+            raise HTTPException(status_code=400, detail="Team with this name already exists")
+
+    if update_request.password:
+        if update_request.password == "":
+            raise HTTPException(status_code=400, detail="Password can not be empty")
+        update_request.password = get_password_hash(update_request.password)
+
+    update_data = update_request.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        if getattr(team, key) != value:
+            setattr(team, key, value)
+    session.commit()
+
+    return team
+
 
 @router.delete(
     "/delete/{id}",
@@ -75,9 +103,8 @@ async def delete(id: int, token: Annotated[str, Depends(oauth2_scheme)]):
     team = session.query(Team).filter(Team.id == id, user.id == Team.owner_id).first()
     if team == None:
         raise HTTPException(status_code=404, detail="Team not found or You aren't the owner of the team")
-    
+
     session.delete(team)
     session.commit()
 
     return user
-

--- a/backend/api/schemas/teams.py
+++ b/backend/api/schemas/teams.py
@@ -1,16 +1,18 @@
 from typing import List, Optional, Generic, TypeVar
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from pydantic.generics import GenericModel
+from datetime import datetime
 
 T = TypeVar("T")
 
- 
+
 class TeamSchema(BaseModel):
     id: Optional[int] = None
     name: Optional[str] = None
     password: Optional[str] = None
     owner_id: Optional[int] = Field(default=None, foreign_key="users.id")
     game_id: Optional[int] = Field(default=None, foreign_key="games.id")
+    created_at: Optional[datetime] = None
 
     class Config:
         orm_mode = True
@@ -21,8 +23,31 @@ class TeamInput(TeamSchema):
     password: str
     game_id: int
 
+    @validator("name", "password")
+    def check_empty_fields(cls, v):
+        assert v != "", "Empty strings are not allowed."
+        return v
+
+    @validator("game_id")
+    def check_positive_numbers(cls, v):
+        assert v >= 0, "Negative numbers are not allowed."
+        return v
+
     class Config:
         orm_mode = True
+
+
+class TeamUpdateRequest(BaseModel):
+    name: Optional[str] = None
+    password: Optional[str] = None
+
+    @validator("*")
+    def check_empty_fields(cls, v):
+        assert v != "", "Empty strings are not allowed."
+        return v
+
+    class Config:
+        extra = "forbid"
 
 
 class Response(GenericModel, Generic[T]):

--- a/backend/api/schemas/teams.py
+++ b/backend/api/schemas/teams.py
@@ -28,6 +28,11 @@ class TeamInput(TeamSchema):
         assert v != "", "Empty strings are not allowed."
         return v
 
+    @validator("name", "password")
+    def check_spaced_fields(cls, v):
+        assert v.strip(), "Empty strings are not allowed."
+        return v
+
     @validator("game_id")
     def check_positive_numbers(cls, v):
         assert v >= 0, "Negative numbers are not allowed."
@@ -44,6 +49,11 @@ class TeamUpdateRequest(BaseModel):
     @validator("*")
     def check_empty_fields(cls, v):
         assert v != "", "Empty strings are not allowed."
+        return v
+
+    @validator("*")
+    def check_spaced_fields(cls, v):
+        assert v.strip(), "Empty strings are not allowed."
         return v
 
     class Config:


### PR DESCRIPTION
## Descrição
Adicionado rota de UPDATE de equipes, assim como validações extras na rota de CREATE de equipes

## Issues Relacionadas
- https://github.com/KozielGPC/championship-platform/issues/106

## Pull Requests Relacionados

## Informações Adicionais
* Rota: `http://localhost:8000/teams/update/{team_id}`
* Body: 

```
{
"name": "Time det testsdfsdfe",
"password": "senha"
}
```
## Checklist:
- [x] Meu código resolve o problema da issue relacionada
- [x] Meu código segue o padrão estrutural definido para esse projeto
- [x] O documento **CHANGELOG** foi atualizado
- [x] Todos os campos de input para atualizar um time foram validados
- [x] Todos os campos de input para criar um time foram validados
- [x] Todas as entidades relacionadas foram validadas (ex: se o jogo recebido realmente existe)
- [x] Somente os campos enviados no `body` do update são atualizados
