### PR TITLE
#89 - Inserção e remoção de users em um time funcionando

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   [#84](https://github.com/KozielGPC/championship-platform/issues/84) - Resolvida validação do formulário de campeonato no frontend
 
 ### Added
+-   [#89](https://github.com/KozielGPC/championship-platform/issues/89) - Adicionado rota para cadastrar um Usuário em um Time
 -   [#108](https://github.com/KozielGPC/championship-platform/issues/108) - Adicionado rota para atualizar um Campeonato
 -   [#107](https://github.com/KozielGPC/championship-platform/issues/107) - Adicionado rota para atualizar um Usuário
 -   [#106](https://github.com/KozielGPC/championship-platform/issues/106) - Adicionado rota para cadastrar Time em um Campeonato

--- a/backend/api/models/team_has_users.py
+++ b/backend/api/models/team_has_users.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Enum, DateTime, Text
+from sqlalchemy.orm import relationship
+from api.database.config import Base
+
+
+class TeamsHasUsers(Base):
+    __tablename__ = "team_has_users"
+    
+    team_id = Column(Integer, ForeignKey("teams.id"), primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), primary_key=True)

--- a/backend/api/models/teams.py
+++ b/backend/api/models/teams.py
@@ -12,3 +12,4 @@ class Team(Base):
     game_id = Column(Integer, ForeignKey("games.id"))
     owner_id = Column(Integer, ForeignKey("users.id"))
     championships = relationship("Championship", secondary="championship_has_teams", backref="championships")
+    users = relationship("User", secondary="team_has_users", backref="users")

--- a/backend/api/models/users.py
+++ b/backend/api/models/users.py
@@ -3,12 +3,13 @@ from api.database.config import Base
 from sqlalchemy.orm import relationship
 
 
-
 class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    username = Column(String, )
+    username = Column(
+        String,
+    )
     password = Column(String)
     email = Column(String)
-    teams = relationship("Team", secondary="team_has_users", backref="times")
+    teams = relationship("Team", secondary="team_has_users", backref="user_teams")

--- a/backend/api/models/users.py
+++ b/backend/api/models/users.py
@@ -1,5 +1,7 @@
 from sqlalchemy import Column, Integer, String
 from api.database.config import Base
+from sqlalchemy.orm import relationship
+
 
 
 class User(Base):
@@ -9,3 +11,4 @@ class User(Base):
     username = Column(String, )
     password = Column(String)
     email = Column(String)
+    teams = relationship("Team", secondary="team_has_users", backref="times")

--- a/backend/api/routers/teams_routes.py
+++ b/backend/api/routers/teams_routes.py
@@ -1,13 +1,23 @@
 from api.database.config import Session, engine
-from api.schemas.teams import Response, TeamInput, TeamSchema, TeamUpdateRequest
+
+from api.schemas.teams import (
+    Response, 
+    TeamInput, 
+    TeamSchema, 
+    AddUserToTeamInput,
+    AddUserToTeamReturn,
+    TeamUpdateRequest
+)
 from api.models.teams import Team
+from api.models.users import User
 from api.models.games import Game
+from api.models.team_has_users import TeamsHasUsers
 from api.utils.auth_services import get_password_hash, oauth2_scheme, get_current_user
 from fastapi import APIRouter, HTTPException, Depends
 from typing import Annotated
 from sqlalchemy.orm import joinedload
-from api.schemas.championships_has_teams import TeamsWithChampionships
-
+from api.schemas.championships_has_teams import TeamsWithChampionships, ChampionshipWithTeams
+from api.schemas.teams_has_users import TeamsWithUsers, UserWithTeams
 from fastapi.encoders import jsonable_encoder
 
 router = APIRouter(
@@ -22,7 +32,7 @@ session = Session(bind=engine)
 
 @router.get(
     "/",
-    response_model=list[TeamsWithChampionships],
+    response_model=list[TeamsWithChampionships], #NÃO SEI SE DEVO COLOCAR OS USERS DO TIME AQUI TBM
     response_description="Sucesso de resposta da aplicação.",
 )
 async def getAll(skip: int = 0, limit: int = 100):
@@ -109,3 +119,84 @@ async def delete(id: int, token: Annotated[str, Depends(oauth2_scheme)]):
     session.commit()
 
     return user
+
+################################################
+#PRECISO ENTENDER COMO VAI SER A DINAMICA DO SOCKET PRA ADICIONAR O USUÁRIO NO TIME
+#SE O ADM PODE SÓ INSERIR UM USUÁRIO PELO ID DELE FDS OU ENTAO SÓ VAI ENTRAR ATRAVES 
+#DO CONVITE VIA SOCKET
+
+#DAQUI PRA BAIXO TA COPIADO DO CAMPEONATO ADICIONANDO TIME, LÁ É PRECISO Q O USER SEJA ADMIN DO CAMP PRA ADICIONAR UM TIME
+#PROVISORIAMENTE VOU MANTER AQUI COMO O UNICO METODO DE ENTRADA SER O ADM COLOCAR ALGUEM PELO ID NA MAO 
+
+@router.post(
+    "/add-user",
+    status_code=200,
+    response_model=AddUserToTeamReturn,
+    response_description="Sucesso de resposta da aplicação.",
+)
+async def addUserToTeam(input: AddUserToTeamInput, token: Annotated[str, Depends(oauth2_scheme)]):
+    user = await get_current_user(token)
+    player = session.query(User).filter(User.id == input.user_id).first()
+    if player == None:
+        raise HTTPException(status_code=404, detail="Player not found")
+    team = session.query(Team).filter(Team.id == input.team_id).first()
+    if team == None:
+        raise HTTPException(status_code=404, detail="Team not found")
+    if team.owner_id != user.id:
+        raise HTTPException(status_code=401, detail="User is not admin of Team")
+
+    team_has_user = (
+        session.query(TeamsHasUsers)
+        .filter(
+            TeamsHasUsers.user_id == input.user_id,
+            TeamsHasUsers.team_id == input.team_id,
+        )
+        .first()
+    )
+    if team_has_user != None:
+        raise HTTPException(status_code=400, detail="Player is already registered in this Team")
+
+    data = TeamsHasUsers(
+        user_id=input.user_id,
+        team_id=input.team_id,
+    )
+    session.add(data)
+    session.commit()
+    session.refresh(data)
+
+    return data
+
+## PRA DELETAR ALGUEM DO TIME É PRECISO SER ADM DO CAMP OU ENTAO VOCÊ MESMO SER O USER QUE VAI SER DELETADO
+
+@router.post(
+    "/remove-user",
+    status_code=200,
+    response_model=AddUserToTeamReturn,
+    response_description="Sucesso de resposta da aplicação.",
+)
+async def addUserToTeam(input: AddUserToTeamInput, token: Annotated[str, Depends(oauth2_scheme)]):
+    user = await get_current_user(token)
+    player = session.query(User).filter(User.id == input.user_id).first()
+    if player == None:
+        raise HTTPException(status_code=404, detail="Player not found")
+    team = session.query(Team).filter(Team.id == input.team_id).first()
+    if team == None:
+        raise HTTPException(status_code=404, detail="Team not found")
+    if team.owner_id != user.id and player.id != user.id :
+        raise HTTPException(status_code=401, detail="User is not the team admin or is not the user to be deleted")
+
+    team_has_user = (
+        session.query(TeamsHasUsers)
+        .filter(
+            TeamsHasUsers.user_id == input.user_id,
+            TeamsHasUsers.team_id == input.team_id,
+        )
+        .first()
+    )
+    if team_has_user == None:
+        raise HTTPException(status_code=404, detail="User isn't registered in this Team")
+
+    session.delete(team_has_user)
+    session.commit()
+
+    return team_has_user

--- a/backend/api/routers/users_routes.py
+++ b/backend/api/routers/users_routes.py
@@ -4,7 +4,8 @@ from api.models.users import User
 from api.utils.auth_services import get_password_hash, oauth2_scheme, get_current_user
 from fastapi import APIRouter, HTTPException, Depends
 from typing import Annotated
-
+from api.models.team_has_users import TeamsHasUsers
+from api.schemas.teams_has_users import TeamsWithUsers, UserWithTeams
 from fastapi.encoders import jsonable_encoder
 
 router = APIRouter(
@@ -19,7 +20,7 @@ session = Session(bind=engine)
 
 @router.get(
     "/",
-    response_model=list[UserSchema],
+    response_model=list[UserWithTeams],
     response_description="Sucesso de resposta da aplicação.",
 )
 async def getAll(token: Annotated[str, Depends(oauth2_scheme)], skip: int = 0, limit: int = 100):
@@ -28,7 +29,7 @@ async def getAll(token: Annotated[str, Depends(oauth2_scheme)], skip: int = 0, l
 
 @router.get(
     "/{id}",
-    response_model=UserSchema,
+    response_model=UserWithTeams,
     response_description="Sucesso de resposta da aplicação.",
 )
 async def getById(id: int, token: Annotated[str, Depends(oauth2_scheme)]):

--- a/backend/api/routers/users_routes.py
+++ b/backend/api/routers/users_routes.py
@@ -5,7 +5,7 @@ from api.utils.auth_services import get_password_hash, oauth2_scheme, get_curren
 from fastapi import APIRouter, HTTPException, Depends
 from typing import Annotated
 from api.models.team_has_users import TeamsHasUsers
-from api.schemas.teams_has_users import TeamsWithUsers, UserWithTeams
+from api.schemas.teams_has_users import UserWithTeams
 from fastapi.encoders import jsonable_encoder
 
 router = APIRouter(

--- a/backend/api/schemas/championships_has_teams.py
+++ b/backend/api/schemas/championships_has_teams.py
@@ -1,10 +1,12 @@
 from api.schemas.teams import TeamSchema
 from api.schemas.championships import ChampionshipSchema
+from api.schemas.users import UserSchema
 from typing import List
 
 
-class TeamsWithChampionships(TeamSchema):
+class TeamsWithRelations(TeamSchema):
     championships: List[ChampionshipSchema] = []
+    users: List[UserSchema] = []
 
 
 class ChampionshipWithTeams(ChampionshipSchema):

--- a/backend/api/schemas/teams.py
+++ b/backend/api/schemas/teams.py
@@ -58,7 +58,26 @@ class TeamUpdateRequest(BaseModel):
 
     class Config:
         extra = "forbid"
+        
+class AddUserToTeamInput(BaseModel):
+    team_id: int
+    user_id: int
 
+    @validator("*")
+    def check_positive_numbers(cls, v):
+        assert v >= 0, "Negative numbers are not allowed."
+        return v
+
+    class Config:
+        orm_mode = True
+
+
+class AddUserToTeamReturn(BaseModel):
+    team_id: int
+    user_id: int
+
+    class Config:
+        orm_mode = True
 
 class Response(GenericModel, Generic[T]):
     code: str

--- a/backend/api/schemas/teams_has_users.py
+++ b/backend/api/schemas/teams_has_users.py
@@ -1,0 +1,11 @@
+from api.schemas.teams import TeamSchema
+from api.schemas.users import UserSchema
+from typing import List
+
+
+class TeamsWithUsers(TeamSchema):
+    users: List[UserSchema] = []
+
+
+class UserWithTeams(UserSchema):
+    teams: List[TeamSchema] = []

--- a/backend/api/schemas/teams_has_users.py
+++ b/backend/api/schemas/teams_has_users.py
@@ -3,9 +3,5 @@ from api.schemas.users import UserSchema
 from typing import List
 
 
-class TeamsWithUsers(TeamSchema):
-    users: List[UserSchema] = []
-
-
 class UserWithTeams(UserSchema):
     teams: List[TeamSchema] = []

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     networks:
       - postgres
     depends_on:
-      - postgresql
+      - postgres
 
 networks:
   postgres:

--- a/backend/migrations/versions/a39f81727889_add_team_has_users_table.py
+++ b/backend/migrations/versions/a39f81727889_add_team_has_users_table.py
@@ -1,0 +1,27 @@
+"""add_team_has_users_table
+
+Revision ID: a39f81727889
+Revises: 005068dcf08f
+Create Date: 2023-05-24 20:07:01.893567
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a39f81727889'
+down_revision = '005068dcf08f'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        "team_has_users",
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("team_id", sa.Integer, sa.ForeignKey("teams.id"), nullable=False),
+        sa.PrimaryKeyConstraint("user_id", "team_id"),
+    )
+
+def downgrade() -> None:
+    op.drop_table("team_has_users")


### PR DESCRIPTION
## Descrição
Inserção e remoção de users em um time. Além da listagem dos times de cada user.

## Issues Relacionadas
#89 

## Pull Requests Relacionados

## Informações Adicionais
Só falta analisar como inserir via socket.
Também precisa ver como faz para listar tanto os campeonatos quanto os players de um time no GET /teams

O QUE FALTA IMPLEMENTAR:

Ocorre a inserção via convite (socket)
Ocorre a listagem de users dentro de cada time (Atualmente só lista os campeonatos que o time faz parte)


ROTAS:
http://localhost:8000/teams/add-user
http://localhost:8000/teams/remove-user

EXEMPLO DE JSON (para ambos os casos):
{
	"user_id": 1,
	"team_id": 2
}

## Checklist:
- [x] Meu código resolve o problema da issue relacionada
- [x] Meu código segue o padrão estrutural definido para esse projeto
- [x] O documento **CHANGELOG** foi atualizado
- [x] o ADMIN do time pode adicionar um user no time
- [x] Somente o ADMIN ou o próprio user pode se remover de um time
- [x] Ocorre a listagem de times que cada user participa
