### PR TITLE
#105 - Adicionado filtro de admin no get de Campeonatos e recebendo filtros por URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   [#84](https://github.com/KozielGPC/championship-platform/issues/84) - Resolvida validação do formulário de campeonato no frontend
 
 ### Added
+-   [#105](https://github.com/KozielGPC/championship-platform/issues/105) - Adicionado filtro de admin no get de Campeonatos e recebendo filtros por URL
 -   [#89](https://github.com/KozielGPC/championship-platform/issues/89) - Adicionado rota para cadastrar um Usuário em um Time
 -   [#108](https://github.com/KozielGPC/championship-platform/issues/108) - Adicionado rota para atualizar um Campeonato
 -   [#107](https://github.com/KozielGPC/championship-platform/issues/107) - Adicionado rota para atualizar um Usuário

--- a/backend/api/routers/championships_routes.py
+++ b/backend/api/routers/championships_routes.py
@@ -4,7 +4,6 @@ from api.schemas.championships import (
     Response,
     ChampionshipInput,
     ChampionshipSchema,
-    FindManyChampionshipFilters,
     AddTeamToChampionshipInput,
     AddTeamToChampionshipReturn,
     ChampionshipUpdateRequest,
@@ -38,18 +37,30 @@ session = Session(bind=engine)
     response_model=list[ChampionshipWithTeams],
     response_description="Sucesso de resposta da aplicação.",
 )
-async def getAll(filters: FindManyChampionshipFilters | None = None, skip: int = 0, limit: int = 100):
+async def getAll(
+    game_id: int = None,
+    admin_id: int = None,
+    max_teams: int = None,
+    min_teams: int = None,
+    format: str = None,
+    name: str = None,
+    skip: int = 0,
+    limit: int = 100
+):
     query = session.query(Championship)
 
-    if filters is not None:
-        if filters.game_id is not None:
-            query = query.filter(Championship.game_id == filters.game_id)
-        if filters.max_teams is not None:
-            query = query.filter(Championship.max_teams <= filters.max_teams)
-        if filters.min_teams is not None:
-            query = query.filter(Championship.min_teams >= filters.min_teams)
-        if filters.format is not None:
-            query = query.filter(Championship.format == filters.format)
+    if game_id is not None:
+        query = query.filter(Championship.game_id == game_id)
+    if max_teams is not None and isinstance(max_teams, int):
+        query = query.filter(Championship.max_teams <= max_teams)
+    if min_teams is not None and isinstance(min_teams, int):
+        query = query.filter(Championship.min_teams >= min_teams)
+    if format is not None and isinstance(format, str):
+        query = query.filter(Championship.format == format)
+    if admin_id is not None and isinstance(admin_id, int):
+        query = query.filter(Championship.admin_id == admin_id) 
+    if name is not None:
+        query = query.filter(Championship.name == name)   
 
     championships = query.options(joinedload(Championship.teams)).offset(skip).limit(limit).all()
 

--- a/backend/api/routers/championships_routes.py
+++ b/backend/api/routers/championships_routes.py
@@ -45,7 +45,7 @@ async def getAll(
     format: str = None,
     name: str = None,
     skip: int = 0,
-    limit: int = 100
+    limit: int = 100,
 ):
     query = session.query(Championship)
 
@@ -58,9 +58,9 @@ async def getAll(
     if format is not None and isinstance(format, str):
         query = query.filter(Championship.format == format)
     if admin_id is not None and isinstance(admin_id, int):
-        query = query.filter(Championship.admin_id == admin_id) 
+        query = query.filter(Championship.admin_id == admin_id)
     if name is not None:
-        query = query.filter(Championship.name == name)   
+        query = query.filter(Championship.name == name)
 
     championships = query.options(joinedload(Championship.teams)).offset(skip).limit(limit).all()
 

--- a/backend/api/schemas/championships.py
+++ b/backend/api/schemas/championships.py
@@ -175,14 +175,3 @@ class Response(GenericModel, Generic[T]):
     status: str
     message: str
     result: Optional[T]
-
-
-class FindManyChampionshipFilters(BaseModel):
-    game_id: Optional[int]
-    format: Optional[EnumFormat]
-    min_teams: Optional[int]
-    max_teams: Optional[int]
-
-    class Config:
-        orm_mode = True
-        use_enum_values = True


### PR DESCRIPTION
## Descrição
Adicionado filtro de admin no get de Campeonatos e recebendo filtros por URL
## Issues Relacionadas
#105 

## Pull Requests Relacionados

## Informações Adicionais
Os filtros disponíveis são: 

    game_id
    admin_id
    max_teams
    min_teams
    format
    name


Semântica da URL:
http://localhost:8000/championships/?admin_id=1
http://localhost:8000/championships/?name=teste&game_id=1

## Checklist:
- [x] Meu código resolve o problema da issue relacionada
- [x] Meu código segue o padrão estrutural definido para esse projeto
- [x] O documento **CHANGELOG** foi atualizado
- [x] É possível listar os campeonatos de acordo com todos os filtro através da URL