### PR TITLE
#126 - Não é mais permitido cadastrar times em um campeonato lotado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   [#65](https://github.com/KozielGPC/championship-platform/issues/65) - Atualizado banco de dados para postgresql
 
 ### Fixed
+-   [#126](https://github.com/KozielGPC/championship-platform/issues/127) - Resolvida validação de inserção de um time em um campeonato cheio
 -   [#84](https://github.com/KozielGPC/championship-platform/issues/84) - Resolvida validação do formulário de campeonato no frontend
 
 ### Added

--- a/frontend/src/pages/profile/teams/index.tsx
+++ b/frontend/src/pages/profile/teams/index.tsx
@@ -142,6 +142,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     }
 
     const response = await getTeams();
+    console.log(response)
     if(response.status == "error"){
       return {
         redirect: {


### PR DESCRIPTION
## Descrição
Validação no backend da inserção de novos times em um campeonato, não sendo mais permitida a inserção de times novos se o campeonato estiver lotado.

## Issues Relacionadas
#126 
## Pull Requests Relacionados
#42 
## Informações Adicionais

## Checklist:
- [ ] Meu código resolve o problema da issue relacionada
- [ ] Meu código segue o padrão estrutural definido para esse projeto
- [ ] O documento **CHANGELOG** foi atualizado
- [ ] Não é mais permitido cadastrar times além do limite máximo