### PR TITLE
131 listar jogos cadastrados no backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@
 -   [#54](https://github.com/KozielGPC/championship-platform/issues/54) - Adicionado formulário de criação de campeonato
 -   [#87](https://github.com/KozielGPC/championship-platform/issues/87) - Adicionado Tela de listagem de minhas equipes
 -   [#44](https://github.com/KozielGPC/championship-platform/issues/44) - Adicionado Tela de edição de um campeonato
+-   [#131](https://github.com/KozielGPC/championship-platform/issues/131) - Adicionado Listagem de jogos cadastrados

--- a/frontend/src/interfaces/index.ts
+++ b/frontend/src/interfaces/index.ts
@@ -34,3 +34,8 @@ export interface Team {
     owner_id: number
     championships: Championship[]
 }
+
+export interface Game {
+    id: number,
+    name: string,
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -9,10 +9,15 @@ import {UserContext} from '../context/UserContext'
 import Layout from '@/components/layout';
 import ShowChampionships from '@/components/showChampionships';
 import { ChampionshipFiltersProps, getChampionships, getChampionshipsFiltered } from '@/services/championship/retrieve';
+import { getGames } from '@/services/games/retrieve';
+import { Game } from '@/interfaces';
 
 const championshipsFilter: ChampionshipFiltersProps = {name: '', min_teams: undefined, max_teams: undefined, game_id: undefined};
+interface Props {
+  games: Game[];
+}
 
-function Home() {
+function Home({games}:Props) {
   const [championships, setChampionships] = useState(Array<Championship>);
   const [championshipsFiltered, setChampionshipsFiltered] = useState<Array<Championship> | undefined>(undefined);
   const [buttonContent, setButtonContent] = useState(false);
@@ -198,16 +203,22 @@ function Home() {
               <NumberInputField h="5%" />
             </NumberInput>
             Select a game:
-            <Select h="5%"
+            <Select h="25px"
               w="96%"
               value={selectedGame}
               onChange={handleSelectChange}
               bg={"white"}
               borderRadius={'none'}
             >
-              <option value='undefined'>Select...</option>
-              <option value="0">League of Legends</option>
-              <option value="1">Valorant</option>
+              {
+                games.map((game) => {
+                  return (
+                    <option key={game.id} value={game.id}>
+                      {game.name}
+                    </option>
+                  );
+                })
+              }
             </Select>
         
             <Button colorScheme="black" variant="outline" size="sm" w="25%" onClick={handleSearchClick} mt={'5px'} mb={'5px'}>
@@ -240,9 +251,16 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     }
   }
 
+  const response = await getGames();
+
+  const games = response.data || [];
+
+
   return(
     {
-      props: {}
+      props: {
+        games: games
+      }
     }
   )
 

--- a/frontend/src/pages/profile/championships/new.tsx
+++ b/frontend/src/pages/profile/championships/new.tsx
@@ -18,7 +18,8 @@ import {useContext} from "react";
 import {UserContext} from '../../../context/UserContext'
 import {dateTime} from '../../../utils/dateTime'
 import {FormErrorMessage } from '../../../components/formErrorMessage'
-
+import { getGames } from "@/services/games/retrieve";
+import { Game } from "@/interfaces";
 interface ChampionshipFormData {
     name: string;
     start_time: string;
@@ -65,7 +66,11 @@ const defaultFormData: ChampionshipFormData = {
   admin_id: 0,
 };
 
-export default function CreateChampionship() {
+interface Props {
+  games: Game[];
+}
+
+export default function CreateChampionship({games}:Props) {
     const router = useRouter();
     const {id} = useContext(UserContext)
     //eslint-disable-next-line react-hooks/rules-of-hooks
@@ -198,7 +203,7 @@ export default function CreateChampionship() {
         errors.visibility = "Required";
       }
 
-      if (!values.game_id) {
+      if (values.game_id==null || values.game_id==undefined) {
         errors.game_id = "Required";
       }
 
@@ -362,8 +367,13 @@ export default function CreateChampionship() {
                                 value={formData.game_id}
                                 onChange={handleSelectChange}
                                 >
-                                    <option value="0">League Of Legends</option>
-                                    <option value="1">Valorant</option>
+                                  {
+                                    games.map((game: Game, index) => {
+                                      return (
+                                        <option key={index} value={game.id}>{game.name}</option>
+                                      )
+                                    })
+                                  }
                                 </Select>
                                 
                             </FormControl>
@@ -390,9 +400,15 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       }
     }
 
+    const response = await getGames();
+
+    const games = response.data || [];
+
     return(
       {
-        props: {}
+        props: {
+          games: games
+        }
       }
     )
 };  

--- a/frontend/src/pages/profile/teams/index.tsx
+++ b/frontend/src/pages/profile/teams/index.tsx
@@ -135,7 +135,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     }
 
     const response = await getTeams();
-    console.log(response)
     if(response.status == "error"){
       return {
         redirect: {

--- a/frontend/src/pages/profile/teams/new.tsx
+++ b/frontend/src/pages/profile/teams/new.tsx
@@ -23,8 +23,15 @@ import { useContext } from "react";
 import { UserContext } from "../../../context/UserContext";
 import jwt_decode from "jwt-decode";
 import Layout from "@/components/layout";
+import { getGames } from "@/services/games/retrieve";
+import { Game } from "@/interfaces";
 
-function CreateTeam(data: User) {
+interface Props {
+  data: User;
+  games: Game[];
+}
+
+function CreateTeam({games }: Props) {
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -179,8 +186,13 @@ function CreateTeam(data: User) {
                 onChange={(e) => handleGameChange(e)}
                 placeholder="Select option"
               >
-                <option value="0">League Of Legends</option>
-                <option value="1">Valorant</option>
+                {
+                  games.map((game: Game, index) => {
+                    return (
+                      <option key={index} value={game.id}>{game.name}</option>
+                    )
+                  })
+                }
               </Select>
             </FormControl>
             <Button colorScheme="blue" type="submit" w="100%">
@@ -204,8 +216,14 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
+  const response = await getGames();
+
+  const games = response.data || [];
+
   return {
-    props: {},
+    props: {
+      games: games,
+    },
   };
 };
 

--- a/frontend/src/services/games/retrieve.ts
+++ b/frontend/src/services/games/retrieve.ts
@@ -1,0 +1,35 @@
+import { Game } from "@/interfaces";
+import axios, { AxiosResponse } from "axios"
+
+export  type Status = "success" | "error";
+
+export  interface ResponseRequest {
+    status: Status;
+    message: string;
+    data?: Array<Game>;
+}
+
+export const getGames= async (): Promise<ResponseRequest> => {
+
+  const response = await axios.get<Array<Game>>(process.env.NEXT_PUBLIC_URL_SERVER+"/games")
+    .then(
+        (response: AxiosResponse<Array<Game>>) => {
+            const status: Status = "success";
+            return {
+                status:status,
+                data: response?.data,
+                message: "Games received with sucess"
+            }}
+    )
+    .catch(
+        (error) => {
+            const status: Status = "error";
+            return {
+                status: status,
+                message: "Error receiving games"
+            }
+        }
+    );
+    return response
+
+};


### PR DESCRIPTION
## Descrição
Jogos que são utilizados nos formulários de campeonato e times agora estão sendo listados.

## Informações Adicionais

## Checklist:
- [x] Tela de novo campeonato lista os jogos cadastrados no banco
- [x] Tela de novo time lista os jogos cadastrados no banco
- [x] Filtros da tela inicial lista os jogos cadastrados no banco
- [x] O documento **CHANGELOG** foi atualizado
